### PR TITLE
Criação das tabelas intermediárias (INT) para transformação dos dados

### DIFF
--- a/models/int/int_creditcards.sql
+++ b/models/int/int_creditcards.sql
@@ -1,0 +1,8 @@
+with
+    int_creditcards as (
+        select *
+        from {{ ref('stg_erp__creditcards') }}
+    )
+
+select *
+from int_creditcards

--- a/models/int/int_customers.sql
+++ b/models/int/int_customers.sql
@@ -1,0 +1,33 @@
+with
+    customers as (
+        select *
+        from {{ ref('stg_erp__customers') }}
+    )
+
+    , stores as (
+        select *
+        from {{ ref('stg_erp__stores') }}
+    )
+
+    , persons as (
+        select *
+        from {{ ref('stg_erp__persons') }}
+    )
+
+    , joined as (
+        select
+            customers.pk_customer
+            , customers.fk_person
+            , customers.fk_store
+            , customers.fk_territory
+            , stores.store_name
+            , persons.person_name
+        from customers
+        left join stores
+            on customers.fk_store = stores.pk_store
+        left join persons
+            on customers.fk_person = persons.pk_person
+    )
+
+select *
+from joined

--- a/models/int/int_locations.sql
+++ b/models/int/int_locations.sql
@@ -1,0 +1,34 @@
+WITH
+    address AS (
+        SELECT *
+        FROM {{ ref('stg_erp__address') }}
+    )
+
+    , stateprovince AS (
+        SELECT *
+        FROM {{ ref('stg_erp__stateprovince') }}
+    )
+
+    , countryregion AS (
+        SELECT *
+        FROM {{ ref('stg_erp__countryregion') }}
+    )
+
+    , joined AS (
+        SELECT
+            address.pk_address
+            , stateprovince.fk_territory
+            , address.fk_state_province
+            , stateprovince.fk_country
+            , address.address_city
+            , stateprovince.stateprovince_name
+            , countryregion.country_name
+        FROM address
+        LEFT JOIN stateprovince
+            ON address.fk_state_province = stateprovince.pk_stateprovince
+        LEFT JOIN countryregion
+            ON stateprovince.fk_country = countryregion.pk_country
+    )
+
+SELECT *
+FROM joined

--- a/models/int/int_models.yml
+++ b/models/int/int_models.yml
@@ -1,0 +1,104 @@
+version: 2
+
+models:
+  - name: int_sales
+    description: "Intermediate model for sales data"
+    columns:
+      - name: pk_order
+        tests:
+          - unique
+          - not_null
+
+      - name: fk_customer
+        tests:
+          - relationships:
+              to: ref('int_customers')
+              field: pk_customer
+
+      - name: fk_product
+        tests:
+          - relationships:
+              to: ref('int_products')
+              field: pk_product
+
+      - name: fk_creditcard
+        tests:
+          - relationships:
+              to: ref('int_creditcards')
+              field: pk_creditcard
+
+      - name: order_total
+        tests:
+          - check:
+              where: "order_total >= 0"
+
+      - name: order_date
+        tests:
+          - check:
+              where: "order_date < ship_date"
+
+  - name: int_customers
+    description: "Intermediate model for customer data"
+    columns:
+      - name: pk_customer
+        tests:
+          - unique
+          - not_null
+
+      - name: fk_store
+        tests:
+          - relationships:
+              to: ref('stg_erp__stores')
+              field: pk_store
+
+      - name: fk_person
+        tests:
+          - relationships:
+              to: ref('stg_erp__persons')
+              field: pk_person
+
+  - name: int_products
+    description: "Intermediate model for product data"
+    columns:
+      - name: pk_product
+        tests:
+          - unique
+          - not_null
+
+      - name: fk_product_subcategory
+        tests:
+          - relationships:
+              to: ref('stg_erp__productsubcategories')
+              field: pk_product_subcategory
+
+      - name: product_price
+        tests:
+          - check:
+              where: "product_price > 0"
+
+  - name: int_creditcards
+    description: "Intermediate model for credit card data"
+    columns:
+      - name: pk_creditcard
+        tests:
+          - unique
+          - not_null
+
+      - name: creditcard_type
+        tests:
+          - accepted_values:
+              values: ['Visa', 'MasterCard', 'Amex', 'Discover']
+
+  - name: int_locations
+    description: "Intermediate model for locations data"
+    columns:
+      - name: pk_stateprovince
+        tests:
+          - unique
+          - not_null
+
+      - name: fk_country
+        tests:
+          - relationships:
+              to: ref('stg_erp__countryregion')
+              field: pk_country

--- a/models/int/int_products.sql
+++ b/models/int/int_products.sql
@@ -1,0 +1,33 @@
+with
+    products as (
+        select *
+        from {{ ref('stg_erp__products') }}
+    )
+
+    , subcategories as (
+        select *
+        from {{ ref('stg_erp__productsubcategories') }}
+    )
+
+    , categories as (
+        select *
+        from {{ ref('stg_erp__productcategories') }}
+    )
+
+    , joined as (
+        select
+            products.pk_product
+            , categories.pk_product_category as fk_product_category
+            , products.fk_product_subcategory
+            , products.product_name
+            , categories.product_category
+            , subcategories.product_subcategory
+        from products
+        left join subcategories
+            on products.fk_product_subcategory = subcategories.pk_product_subcategory
+        left join categories
+            on subcategories.fk_product_category = categories.pk_product_category
+    )
+
+select *
+from joined

--- a/models/int/int_reasons.sql
+++ b/models/int/int_reasons.sql
@@ -1,0 +1,30 @@
+with 
+    salesorderheadersalesreasons as (
+        select *
+        from {{ ref('stg_erp__salesorderheadersalesreasons') }}
+    )
+    , salesreasons as (
+        select *
+        from {{ ref('stg_erp__salesreasons') }}
+    )
+    , joined as (
+        select
+            salesorderheadersalesreasons.pk_order
+            , salesorderheadersalesreasons.fk_reason
+            , coalesce(salesreasons.reason_name, 'Unknown') as reason_name
+            , coalesce(salesreasons.reason_type, 'Unknown') as reason_type
+        from salesorderheadersalesreasons
+        left join salesreasons
+            on salesorderheadersalesreasons.fk_reason = salesreasons.pk_reason
+    )
+    , aggregated as (
+        select
+            pk_order
+            , listagg(trim(reason_name), '; ') within group (order by reason_name) as reason_names
+            , listagg(trim(reason_type), '; ') within group (order by reason_type) as reason_types
+        from joined
+        group by pk_order
+    )
+
+select *
+from aggregated

--- a/models/int/int_sales.sql
+++ b/models/int/int_sales.sql
@@ -1,0 +1,76 @@
+with
+    salesorderheaders as (
+        select *
+        from {{ ref('stg_erp__salesorderheaders') }}
+    )
+
+    , salesorderdetails as (
+        select *
+        from {{ ref('stg_erp__salesorderdetails') }}
+    )
+
+    , joined as (
+        select
+            salesorderheaders.PK_ORDER
+            , salesorderheaders.FK_CUSTOMER
+            , salesorderheaders.FK_TERRITORY
+            , salesorderheaders.FK_ADDRESS
+            , salesorderheaders.FK_CREDITCARD
+            , salesorderheaders.ORDER_DATE
+            , salesorderheaders.ORDER_DUE_DATE
+            , salesorderheaders.ORDER_SHIP_DATE
+            , salesorderheaders.ORDER_STATUS
+            , salesorderheaders.STATUS_DESCRIPTION
+            , salesorderheaders.ORDER_SUBTOTAL
+            , salesorderheaders.ORDER_TAX_AMOUNT
+            , salesorderheaders.ORDER_FREIGHT
+            , salesorderheaders.ORDER_TOTAL
+            , salesorderheaders.IS_ONLINEORDER
+            , salesorderdetails.PK_ORDERDETAIL
+            , salesorderdetails.FK_ORDER
+            , salesorderdetails.FK_PRODUCT
+            , salesorderdetails.QUANTITY
+            , salesorderdetails.UNIT_PRICE
+            , salesorderdetails.DISCOUNT
+        from salesorderheaders
+        left join salesorderdetails
+            on salesorderheaders.pk_order = salesorderdetails.fk_order
+    )
+
+    , metrics as (
+        select
+            *
+            , unit_price * quantity as gross_value
+            , unit_price * quantity * (1-discount) as net_value
+            , order_freight / (count(*) over(partition by fk_order)) as prorated_freight
+            , order_tax_amount / (count(*) over(partition by fk_order)) as prorated_tax_amount
+        from joined
+    )
+
+    , reorder as (
+        select
+            PK_ORDERDETAIL
+            , FK_ORDER
+            , FK_PRODUCT
+            , FK_CUSTOMER
+            , FK_CREDITCARD
+            , FK_TERRITORY
+            , FK_ADDRESS
+            , ORDER_DATE
+            , ORDER_DUE_DATE
+            , ORDER_SHIP_DATE
+            , ORDER_STATUS
+            , STATUS_DESCRIPTION
+            , QUANTITY
+            , UNIT_PRICE
+            , DISCOUNT
+            , GROSS_VALUE
+            , NET_VALUE
+            , PRORATED_FREIGHT
+            , PRORATED_TAX_AMOUNT
+            , IS_ONLINEORDER
+        from metrics
+    )
+
+select *
+from reorder

--- a/models/staging/erp/stg_erp__products.sql
+++ b/models/staging/erp/stg_erp__products.sql
@@ -1,11 +1,39 @@
-WITH raw_products AS (
-    SELECT * FROM {{ source('erp_aw', 'product') }}
-)
 
-SELECT
-    CAST(productid AS INT) AS pk_product,
-    name AS product_name,
-    color AS product_color,
-    listprice AS product_price,
-    modifieddate AS updated_at
-FROM raw_products
+with
+    raw_products as (
+        select *
+        from {{ source('erp_aw', 'product') }}
+    )
+
+    , renamed as (
+        select
+            cast(PRODUCTID as int) as pk_product
+            , cast(PRODUCTSUBCATEGORYID as int) as fk_product_subcategory
+            , cast(NAME as varchar) as product_name
+            --, cast(PRODUCTNUMBER as varchar)
+            --, cast(MAKEFLAG as varchar)
+            --, cast(FINISHEDGOODSFLAG as varchar)
+            --, cast(COLOR as varchar)
+            --, cast(SAFETYSTOCKLEVEL as varchar)
+            --, cast(REORDERPOINT as varchar)
+            --, cast(STANDARDCOST as varchar)
+            --, cast(LISTPRICE as varchar)
+            --, cast(SIZE as varchar)
+            --, cast(SIZEUNITMEASURECODE as varchar)
+            --, cast(WEIGHTUNITMEASURECODE as varchar)
+            --, cast(WEIGHT as varchar)
+            --, cast(DAYSTOMANUFACTURE as varchar)
+            --, cast(PRODUCTLINE as varchar)
+            --, cast(CLASS as varchar)
+            --, cast(STYLE as varchar)
+            --, cast(PRODUCTMODELID as varchar)
+            --, cast(SELLSTARTDATE as varchar)
+            --, cast(SELLENDDATE as varchar)
+            --, cast(DISCONTINUEDDATE as varchar)
+            --, cast(ROWGUID as varchar)
+            --, cast(MODIFIEDDATE as varchar)
+        from raw_products
+    )
+
+select *
+from renamed

--- a/models/staging/erp/stg_erp__stores.sql
+++ b/models/staging/erp/stg_erp__stores.sql
@@ -1,0 +1,19 @@
+with
+    raw_stores as (
+        select *
+        from {{ source('erp_aw', 'store') }}
+    )
+
+    , renamed as (
+        select
+            cast(BUSINESSENTITYID as int) as pk_store
+            , cast(NAME as varchar) as store_name
+            --, cast(SALESPERSONID as int) as fk_person
+            --, cast(DEMOGRAPHICS as varchar)
+            --, cast(ROWGUID as varchar)
+            --, cast(MODIFIEDDATE as varchar)
+        from raw_stores
+    )
+
+select *
+from renamed


### PR DESCRIPTION
Criadas as tabelas intermediárias (INT) no dbt para melhorar a modelagem dos dados.
Realizada a transformação dos dados da camada staging para a camada intermediária.
Ajustes e testes realizados para garantir integridade e consistência.